### PR TITLE
Add id = "player" to iframe

### DIFF
--- a/chrome/content.js
+++ b/chrome/content.js
@@ -201,7 +201,7 @@ chrome.runtime.onMessage.addListener(
             const iframe = document.createElement('iframe');
             iframe.src = request.url;
             updateIframeStyle(video.highest, iframe, isYt, playerFillsScreen);
-
+            iframe.id = "player";
             iframe.allowFullscreen = true;
             iframe.allow = 'autoplay; fullscreen; picture-in-picture';
 

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -3,7 +3,7 @@
   "default_locale": "en",
   "name": "__MSG_extension_name__",
   "description": "__MSG_extension_description__",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "author": "Andrew S",
   "options_ui": {
     "page": "player/options/index.html",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faststream",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "description": "Stream videos without buffering. Fix bad video players on the internet.",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
I'm using an extension called "Comments Sidebar for Youtube" and FastStream is broken whenever that extension is active. Adding id = "player" makes the player snap to the place it's supposed to, although I wish I could figure out how to make FastStream properly resize when the split bar is moved, at least going to fullscreen and back does the job at resizing it.