### PR TITLE
Add styling tag conversion for SRT/ASS subtitles to WebVTT

### DIFF
--- a/chrome/player/SubtitleTrack.mjs
+++ b/chrome/player/SubtitleTrack.mjs
@@ -30,6 +30,11 @@ export class SubtitleTrack {
     } else if (text.trim().split('\n')[0].trim().substr(0, 6) !== 'WEBVTT') {
       text = SubtitleUtils.srt2webvtt(text);
     }
+
+    // sometimes formatting in subtitles are not properly 
+    // converted into webvtt, so we need to convert them manually
+    text = SubtitleUtils.convertSubtitleFormatting(text)
+
     // eslint-disable-next-line new-cap
     const parser = new WebVTT.Parser(window, WebVTT.StringDecoder());
     parser.onRegion = (region) => {

--- a/chrome/player/utils/SubtitleUtils.mjs
+++ b/chrome/player/utils/SubtitleUtils.mjs
@@ -148,4 +148,13 @@ export class SubtitleUtils {
     }
     return cue;
   }
+
+  static convertSubtitleFormatting(text) {
+    return text
+      .replace(/\{\\([ibu])1\}/g, '<$1>') // convert {\b1}, {\i1}, {\u1} to <b>, <i>, <u>
+      .replace(/\{\\([ibu])\}/g, '</$1>') // convert {\b}, {\i}, {\u} to </b>, </i>, </u>
+      .replace(/\{([ibu])\}/g, '<$1>') // convert {b}, {i}, {u} to <b>, <i>, <u>
+      .replace(/\{\/([ibu])\}/g, '</$1>') // convert {/b}, {/i}, {/u} to </b>, </i>, </u>
+      .replace(/(\r\n|\n)\{\\an8\}/g, ' line:5%\n'); // handle top positioning
+  }
 }


### PR DESCRIPTION
# Problem
Subtitles from OpenSubtitles occasionally come in WebVTT format but retain SRT/ASS styling tags (e.g., `{\an8}`). This indicates incomplete conversion from the original format. While our video player doesn't currently support subtitle styling, we should ensure our WebVTT files conform to the [official specification](https://developer.mozilla.org/en-US/docs/Web/API/WebVTT_API/Web_Video_Text_Tracks_Format) for future compatibility.

![image](https://github.com/user-attachments/assets/74a525e9-0f45-4ed6-951f-ff553312c0d2)

# Solution
Added styling tag conversion to properly transform SRT/ASS formatting into WebVTT-compliant styling. The conversion handles:
- Basic text styling: bold, italic, underline
- Text alignment tags (e.g., `{\an8}` → `line:5%`)

# Implementation Details
- Added support for multiple tag formats:
  - `{\b1}`, `{\i1}`, `{\u1}` → `<b>`, `<i>`, `<u>`
  - `{\b}`, `{\i}`, `{\u}` → closing tags
  - `{b}`, `{i}`, `{u}` → opening tags
  - `{/b}`, `{/i}`, `{/u}` → closing tags
- Converted alignment tags to WebVTT positioning

## Next Steps
- Implement subtitle styling rendering in video player