### PR TITLE
feat: github actions auto build & release artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,3 +24,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: built/*.zip
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: built/*.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+    tags:
+      - "v*.*.*"
+      - "V*.*.*"
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build and upload artifacts
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build and upload artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          path: built/*.zip

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "faststream",
-  "version": "1.0.19",
+  "version": "1.3.44",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "faststream",
-      "version": "1.0.19",
+      "version": "1.3.44",
       "devDependencies": {
         "eslint": "^8.49.0",
         "eslint-config-google": "^0.14.0",


### PR DESCRIPTION
Great extension!

Just wanna contribute the workflow:

* Every time you push a commit to `main`, it will auto build & upload the artifacts, so we always have latest update.
* Every time you push a tag, it will auto build, create a release and upload the artifacts to that release!

See my example, after I pushed the tag `V1.3.44-RC3`, release is auto created: https://github.com/jackblk/FastStream/releases/tag/V1.3.44-RC3

Unrelated to the PR, can you publish the extension to Edge store with the libre version?