### PR TITLE
Apply Twitch-specific config only when on twitch.tv

### DIFF
--- a/chrome/content.js
+++ b/chrome/content.js
@@ -37,7 +37,7 @@
     customIframeId: null,
   };
 
-  if (window.location.origin = 'https://www.twitch.tv') {
+  if (window.location.origin === 'https://www.twitch.tv') {
     Config.softReplaceByDefault = false;
   }
 


### PR DESCRIPTION
## PR Summary
This small PR ensures that the Twitch-specific config is applied only when the page is on `twitch.tv`.