### PR TITLE
[Feature] Persist Buffered Chunks Across Reload

### DIFF
--- a/chrome/_locales/en/messages.json
+++ b/chrome/_locales/en/messages.json
@@ -938,6 +938,15 @@
     "options_general_storeprogress": {
         "message": "Play videos from last watched position"
     },
+    "options_general_persistbuffer": {
+        "message": "Persist buffered video chunks to storage"
+    },
+    "options_general_persistbuffer_retention": {
+        "message": "Buffered chunk retention (days, 1-30)"
+    },
+    "options_general_persistbuffer_maxsize": {
+        "message": "Persistent chunk cache size limit (MB, 0 = unlimited)"
+    },
     "options_general_autosub": {
         "message": "Automatically enable best found subtitle track\n(Change default language in subtitle settings)"
     },

--- a/chrome/player/FastStreamClient.mjs
+++ b/chrome/player/FastStreamClient.mjs
@@ -89,6 +89,9 @@ export class FastStreamClient extends EventEmitter {
       videoRotate: 0,
       disableVisualFilters: false,
       maximumDownloaders: 6,
+      persistBufferedVideos: true,
+      persistBufferRetentionDays: 7,
+      persistBufferMaxSizeMB: 1024,
       maxPlaybackRate: EnvUtils.isChrome() ? 16 : 8,
       youtubePlayerID: '',
     };
@@ -319,6 +322,9 @@ export class FastStreamClient extends EventEmitter {
     // this.options.defaultYoutubeClient = options.defaultYoutubeClient;
     this.options.youtubePlayerID = options.youtubePlayerID;
     this.options.maximumDownloaders = options.maximumDownloaders;
+    this.options.persistBufferedVideos = !!options.persistBufferedVideos;
+    this.options.persistBufferRetentionDays = Math.min(Math.max(parseInt(options.persistBufferRetentionDays ?? 7, 10), 1), 30);
+    this.options.persistBufferMaxSizeMB = Math.max(parseInt(options.persistBufferMaxSizeMB ?? 0, 10), 0);
 
     if (sessionStorage && sessionStorage.getItem('autoplayNext') !== null) {
       this.options.autoplayNext = sessionStorage.getItem('autoplayNext') == 'true';
@@ -382,6 +388,8 @@ export class FastStreamClient extends EventEmitter {
       this.options.toolSettings = options.toolSettings;
       this.interfaceController.updateToolVisibility();
     }
+
+    this.downloadManager.setOptions(this.options);
 
     this.updateHasDownloadSpace();
     this.interfaceController.updateAutoNextIndicator();

--- a/chrome/player/modules/FSBlob.mjs
+++ b/chrome/player/modules/FSBlob.mjs
@@ -1,92 +1,180 @@
 import {IndexedDBManager} from '../network/IndexedDBManager.mjs';
 import {AlertPolyfill} from '../utils/AlertPolyfill.mjs';
 import {EnvUtils} from '../utils/EnvUtils.mjs';
+import {Utils} from '../utils/Utils.mjs';
 import {Localize} from './Localize.mjs';
 
 const BrowserCanAutoOffloadBlobs = EnvUtils.isChrome();
-const UseCache = !BrowserCanAutoOffloadBlobs && window.caches;
-const UseIndexedDB = !BrowserCanAutoOffloadBlobs && !UseCache && IndexedDBManager.isSupported();
+const UseCacheByDefault = !BrowserCanAutoOffloadBlobs && window.caches;
+const UseIndexedDBByDefault = !BrowserCanAutoOffloadBlobs && !UseCacheByDefault && IndexedDBManager.isSupported();
+
+const PersistentCacheDBName = 'faststream-buffer-cache-v1';
+const PersistentCacheVersion = 1;
+const DefaultPersistenceConfig = {
+  enabled: false,
+  retentionDays: 7,
+  maxBytes: 0,
+};
 
 export class FSBlob {
-  constructor() {
+  constructor(config) {
     this.blobStore = new Map();
     this.blobStorePromises = new Map();
 
-    try {
-      if (UseCache) {
-        this.cache = true;
-        this.setupPromise = this.setupOrphanedCache();
-      } else if (UseIndexedDB) {
-        this.indexedDBManager = new IndexedDBManager();
-        this.setupPromise = this.indexedDBManager.setup();
-      }
-    } catch (e) {
-      console.warn('FSBlob setup failed, falling back to memory storage', e);
-      this.cache = null;
-      this.indexedDBManager = null;
-      this.setupPromise = null;
-      this.blobStorePromises.clear();
-      AlertPolyfill.alert(Localize.getMessage('player_outofstorage'));
+    this.cache = null;
+    this.indexedDBManager = null;
+    this.setupPromise = Promise.resolve();
+    this.backendType = 'memory';
+    this.cleanupTimer = null;
+    this.cleanupPromise = null;
+    this.configurePromise = Promise.resolve();
+    this.persistenceConfig = {...DefaultPersistenceConfig};
+    this.initialized = false;
+    this.blobIndex = 0;
+
+    this.configure(config || {}).catch((e) => {
+      console.warn('FSBlob configure failed, using memory storage', e);
+    });
+  }
+
+  normalizePersistenceConfig(config) {
+    const normalized = {
+      ...DefaultPersistenceConfig,
+      ...(config || {}),
+    };
+
+    normalized.enabled = !!normalized.enabled;
+
+    let retentionDays = parseInt(normalized.retentionDays, 10);
+    if (isNaN(retentionDays)) retentionDays = DefaultPersistenceConfig.retentionDays;
+    normalized.retentionDays = Math.min(Math.max(retentionDays, 1), 30);
+
+    let maxBytes = parseInt(normalized.maxBytes, 10);
+    if (isNaN(maxBytes) || maxBytes < 0) maxBytes = 0;
+    normalized.maxBytes = maxBytes;
+
+    return normalized;
+  }
+
+  shouldUsePersistentBackend(config) {
+    return !!config.enabled && !EnvUtils.isIncognito() && IndexedDBManager.isSupported();
+  }
+
+  configure(config) {
+    const normalized = this.normalizePersistenceConfig(config);
+    const changed = !this.initialized ||
+      this.persistenceConfig.enabled !== normalized.enabled ||
+      this.persistenceConfig.retentionDays !== normalized.retentionDays ||
+      this.persistenceConfig.maxBytes !== normalized.maxBytes;
+
+    if (!changed) {
+      return this.configurePromise;
     }
 
-    this.blobIndex = 0;
+    const currentPersistentBackend = this.backendType === 'persistent-indexeddb';
+    const nextPersistentBackend = this.shouldUsePersistentBackend(normalized);
+
+    if (this.initialized && currentPersistentBackend === nextPersistentBackend &&
+      this.persistenceConfig.enabled === normalized.enabled) {
+      this.persistenceConfig = normalized;
+      if (nextPersistentBackend) {
+        this.configurePromise = this.configurePromise.then(async () => {
+          await this.prunePersistentStorage(true);
+        }).catch((e) => {
+          console.warn('FSBlob persistent cleanup failed', e);
+        });
+      }
+      return this.configurePromise;
+    }
+
+    this.configurePromise = this.configurePromise.then(async () => {
+      await this.reinitializeBackend(normalized);
+    }).catch((e) => {
+      console.warn('FSBlob reconfigure failed, using memory storage', e);
+      this.resetToMemoryBackend();
+    });
+
+    return this.configurePromise;
+  }
+
+  async reinitializeBackend(config) {
+    const previousConfig = this.persistenceConfig;
+    const previousBackend = this.backendType;
+
+    this.persistenceConfig = config;
+    this.initialized = true;
+
+    clearTimeout(this.cleanupTimer);
+    this.cleanupTimer = null;
+
+    await this.closeBackend();
+    this.blobStore.clear();
+    this.blobStorePromises.clear();
+
+    if (previousBackend === 'persistent-indexeddb' && !config.enabled && previousConfig.enabled) {
+      await IndexedDBManager.deleteDB(PersistentCacheDBName);
+    }
+
+    if (this.shouldUsePersistentBackend(config)) {
+      this.backendType = 'persistent-indexeddb';
+      this.indexedDBManager = new IndexedDBManager(PersistentCacheDBName);
+      this.setupPromise = this.indexedDBManager.setup();
+      await this.setupPromise;
+      await this.prunePersistentStorage(true);
+      return;
+    }
+
+    if (UseCacheByDefault) {
+      this.backendType = 'cache';
+      this.cache = true;
+      this.setupPromise = this.setupOrphanedCache();
+      await this.setupPromise;
+      return;
+    }
+
+    if (UseIndexedDBByDefault) {
+      this.backendType = 'temp-indexeddb';
+      this.indexedDBManager = new IndexedDBManager();
+      this.setupPromise = this.indexedDBManager.setup();
+      await this.setupPromise;
+      return;
+    }
+
+    this.setupPromise = Promise.resolve();
+    this.backendType = 'memory';
+  }
+
+  resetToMemoryBackend() {
+    clearTimeout(this.cleanupTimer);
+    this.cleanupTimer = null;
+    this.cache = null;
+    this.indexedDBManager = null;
+    this.setupPromise = Promise.resolve();
+    this.backendType = 'memory';
+    this.blobStore.clear();
+    this.blobStorePromises.clear();
+    AlertPolyfill.alert(Localize.getMessage('player_outofstorage'));
+  }
+
+  async closeBackend() {
+    this.cache = null;
+    if (this.indexedDBManager) {
+      try {
+        await this.indexedDBManager.close();
+      } catch (e) {
+        console.warn(e);
+      }
+      this.indexedDBManager = null;
+    }
+    this.setupPromise = Promise.resolve();
   }
 
   async setupOrphanedCache() {
     const cacheName = 'blob-cache-' + Date.now() + '-' + Math.random();
     const cache = await window.caches.open(cacheName);
-    // Orphan it!
+    // Orphan it so browser can reclaim when tab closes.
     await window.caches.delete(cacheName);
-    // Store the cache reference for later use
     this.cache = cache;
-  }
-
-  async saveBlobInIndexedDBAsync(identifier, blob) {
-    try {
-      await this.setupPromise;
-    } catch (e) {
-      // IndexedDB is not supported
-      console.warn('IndexedDB is not supported, falling back to memory storage');
-      this.indexedDBManager = null;
-      this.setupPromise = false;
-      this.blobStorePromises.clear();
-      return false;
-    }
-    // Store file
-    await this.indexedDBManager.setFile(identifier, blob);
-    // Get file
-    const file = await this.indexedDBManager.getFile(identifier);
-
-    if (EnvUtils.isFirefox()) {
-      // Delete file to orphan it
-      await this.indexedDBManager.deleteFile(identifier);
-    }
-
-    this.blobStore.set(identifier, file);
-    return true;
-  }
-
-  async saveBlobUsingCache(identifier, blob) {
-    try {
-      await this.setupPromise;
-    } catch (e) {
-      console.warn('Cache API is not supported, falling back to memory storage');
-      this.cache = null;
-      this.setupPromise = false;
-      this.blobStorePromises.clear();
-      return false;
-    }
-
-    const response = new Response(blob);
-    const identifierURL = this.getIdentifierURL(identifier);
-
-    await this.cache.put(identifierURL, response);
-
-    const match = await this.cache.match(identifierURL);
-
-    const blobResponse = await match?.blob();
-
-    this.blobStore.set(identifier, blobResponse);
   }
 
   getIdentifierURL(identifier) {
@@ -97,21 +185,174 @@ export class FSBlob {
     return `blob${this.blobIndex++}`;
   }
 
+  setBlobEntry(identifier, data, size) {
+    this.blobStore.set(identifier, {
+      data,
+      size: size === undefined ? Utils.getDataByteSize(data) : size,
+    });
+  }
+
+  getBlobEntry(identifier) {
+    return this.blobStore.get(identifier) || null;
+  }
+
+  getRetentionCutoff() {
+    return Date.now() - this.persistenceConfig.retentionDays * 24 * 60 * 60 * 1000;
+  }
+
+  isExpiredMetadata(metadata) {
+    const lastAccessed = metadata?.lastAccessed || metadata?.createdAt || 0;
+    return lastAccessed < this.getRetentionCutoff();
+  }
+
+  schedulePersistentCleanup() {
+    if (this.backendType !== 'persistent-indexeddb' || this.cleanupTimer) return;
+    this.cleanupTimer = setTimeout(() => {
+      this.cleanupTimer = null;
+      this.prunePersistentStorage().catch((e) => {
+        console.warn('Persistent cache cleanup failed', e);
+      });
+    }, 1000);
+  }
+
+  async prunePersistentStorage(force = false) {
+    if (this.backendType !== 'persistent-indexeddb' || !this.indexedDBManager) return;
+    if (this.cleanupPromise && !force) return this.cleanupPromise;
+
+    const run = async () => {
+      await this.setupPromise;
+
+      const now = Date.now();
+      const allMetadata = await this.indexedDBManager.getAllFileMetadata();
+      const staleIdentifiers = [];
+      const candidates = [];
+
+      allMetadata.forEach((meta) => {
+        const identifier = meta?.identifier;
+        if (!identifier) {
+          return;
+        }
+
+        if (meta.cacheVersion !== PersistentCacheVersion || this.isExpiredMetadata(meta)) {
+          staleIdentifiers.push(identifier);
+          return;
+        }
+
+        const size = parseInt(meta.size, 10) || 0;
+        const lastAccessed = parseInt(meta.lastAccessed, 10) || parseInt(meta.createdAt, 10) || now;
+        candidates.push({
+          identifier,
+          size,
+          lastAccessed,
+        });
+      });
+
+      await Promise.all(staleIdentifiers.map((identifier) => this.deletePersistentEntry(identifier)));
+
+      if (this.persistenceConfig.maxBytes <= 0) {
+        return;
+      }
+
+      let totalSize = candidates.reduce((sum, item) => sum + item.size, 0);
+      if (totalSize <= this.persistenceConfig.maxBytes) {
+        return;
+      }
+
+      candidates.sort((a, b) => a.lastAccessed - b.lastAccessed);
+      const evicted = [];
+      while (candidates.length > 0 && totalSize > this.persistenceConfig.maxBytes) {
+        const item = candidates.shift();
+        evicted.push(item.identifier);
+        totalSize -= item.size;
+      }
+
+      await Promise.all(evicted.map((identifier) => this.deletePersistentEntry(identifier)));
+    };
+
+    this.cleanupPromise = run().finally(() => {
+      this.cleanupPromise = null;
+    });
+
+    return this.cleanupPromise;
+  }
+
+  async deletePersistentEntry(identifier) {
+    this.blobStore.delete(identifier);
+    this.blobStorePromises.delete(identifier);
+    if (!this.indexedDBManager) return;
+
+    await Promise.all([
+      this.indexedDBManager.deleteFile(identifier),
+      this.indexedDBManager.deleteFileMetadata(identifier),
+    ]);
+  }
+
+  async saveBlobUsingCache(identifier, blob) {
+    await this.setupPromise;
+
+    const response = new Response(blob);
+    const identifierURL = this.getIdentifierURL(identifier);
+    await this.cache.put(identifierURL, response);
+    const match = await this.cache.match(identifierURL);
+    const cachedBlob = await match?.blob();
+
+    this.setBlobEntry(identifier, cachedBlob || blob);
+    return true;
+  }
+
+  async saveBlobInIndexedDBAsync(identifier, blob) {
+    await this.setupPromise;
+
+    await this.indexedDBManager.setFile(identifier, blob);
+
+    if (this.backendType === 'persistent-indexeddb') {
+      const now = Date.now();
+      const existingMeta = await this.indexedDBManager.getFileMetadata(identifier);
+      const metadata = {
+        identifier,
+        size: Utils.getDataByteSize(blob),
+        createdAt: existingMeta?.createdAt || now,
+        lastAccessed: now,
+        cacheVersion: PersistentCacheVersion,
+      };
+      await this.indexedDBManager.setFileMetadata(identifier, metadata);
+      this.setBlobEntry(identifier, blob, metadata.size);
+      this.schedulePersistentCleanup();
+      return true;
+    }
+
+    const file = await this.indexedDBManager.getFile(identifier);
+    if (EnvUtils.isFirefox()) {
+      await this.indexedDBManager.deleteFile(identifier);
+    }
+    this.setBlobEntry(identifier, file || blob);
+    return true;
+  }
+
   async saveBlobAsync(blob, identifier) {
+    await this.configurePromise;
+
     if (!identifier) {
       identifier = this.nextIdentifier();
     }
-    this.blobStore.set(identifier, blob);
-    let promise;
-    if (this.cache) {
-      promise = this.saveBlobUsingCache(identifier, blob);
-    } else if (this.indexedDBManager) {
-      promise = this.saveBlobInIndexedDBAsync(identifier, blob);
+
+    this.setBlobEntry(identifier, blob);
+
+    let promise = Promise.resolve(true);
+    try {
+      if (this.backendType === 'cache') {
+        promise = this.saveBlobUsingCache(identifier, blob);
+      } else if (this.backendType === 'temp-indexeddb' || this.backendType === 'persistent-indexeddb') {
+        promise = this.saveBlobInIndexedDBAsync(identifier, blob);
+      }
+    } catch (e) {
+      console.warn('Blob backend write failed, using memory fallback', e);
+      this.resetToMemoryBackend();
+      promise = Promise.resolve(false);
     }
+
     this.blobStorePromises.set(identifier, promise);
-
     await promise;
-
     return identifier;
   }
 
@@ -126,43 +367,121 @@ export class FSBlob {
     return this.saveBlob(blob);
   }
 
+  async getStoredBlobEntry(identifier) {
+    await this.configurePromise;
+
+    if (this.blobStorePromises.has(identifier)) {
+      await this.blobStorePromises.get(identifier).catch(() => {});
+    }
+
+    const inMemory = this.getBlobEntry(identifier);
+    if (inMemory) {
+      return inMemory;
+    }
+
+    if (this.backendType === 'cache' && this.cache) {
+      await this.setupPromise;
+      const identifierURL = this.getIdentifierURL(identifier);
+      const response = await this.cache.match(identifierURL);
+      if (!response) return null;
+      const blob = await response.blob();
+      this.setBlobEntry(identifier, blob);
+      return this.getBlobEntry(identifier);
+    }
+
+    if (this.backendType === 'persistent-indexeddb' && this.indexedDBManager) {
+      await this.setupPromise;
+
+      const metadata = await this.indexedDBManager.getFileMetadata(identifier);
+      if (!metadata) return null;
+
+      if (metadata.cacheVersion !== PersistentCacheVersion || this.isExpiredMetadata(metadata)) {
+        await this.deletePersistentEntry(identifier);
+        return null;
+      }
+
+      const file = await this.indexedDBManager.getFile(identifier);
+      if (!file) {
+        await this.indexedDBManager.deleteFileMetadata(identifier);
+        return null;
+      }
+
+      const now = Date.now();
+      metadata.lastAccessed = now;
+      if (!metadata.size) {
+        metadata.size = Utils.getDataByteSize(file);
+      }
+      await this.indexedDBManager.setFileMetadata(identifier, metadata);
+
+      this.setBlobEntry(identifier, file, metadata.size);
+      return this.getBlobEntry(identifier);
+    }
+
+    return null;
+  }
+
+  async getBlob(identifier) {
+    const record = await this.getStoredBlobEntry(identifier);
+    return record?.data || null;
+  }
+
   async deleteBlob(identifier) {
     this.blobStore.delete(identifier);
 
     if (this.blobStorePromises.has(identifier)) {
-      await this.blobStorePromises.get(identifier);
+      await this.blobStorePromises.get(identifier).catch(() => {});
     }
 
     this.blobStore.delete(identifier);
     this.blobStorePromises.delete(identifier);
-    if (this.cache) {
+
+    if (this.backendType === 'cache' && this.cache) {
+      await this.setupPromise;
       const identifierURL = this.getIdentifierURL(identifier);
       await this.cache.delete(identifierURL);
-    } else if (this.indexedDBManager) {
+    } else if ((this.backendType === 'temp-indexeddb' || this.backendType === 'persistent-indexeddb') && this.indexedDBManager) {
+      await this.setupPromise;
       await this.indexedDBManager.deleteFile(identifier);
+      if (this.backendType === 'persistent-indexeddb') {
+        await this.indexedDBManager.deleteFileMetadata(identifier);
+      }
     }
 
     return true;
   }
 
-  getBlob(identifier) {
-    return this.blobStore.get(identifier);
-  }
+  async clear(options = {}) {
+    const clearPersistent = options.clearPersistent !== false;
 
-  async clear() {
     this.blobStore.clear();
     this.blobStorePromises.clear();
-    if (this.cache) {
-      // Setup a new cache entirely
+
+    if (this.backendType === 'cache' && this.cache) {
       this.cache = true;
       this.setupPromise = this.setupOrphanedCache();
       await this.setupPromise;
-    } else if (this.indexedDBManager) {
+      return;
+    }
+
+    if ((this.backendType === 'temp-indexeddb' || this.backendType === 'persistent-indexeddb') && this.indexedDBManager) {
+      await this.setupPromise;
+
+      if (this.backendType === 'persistent-indexeddb' && !clearPersistent) {
+        return;
+      }
+
       await this.indexedDBManager.clearStorage();
+      if (this.backendType === 'persistent-indexeddb') {
+        await this.indexedDBManager.clearFileMetadataStorage();
+      }
     }
   }
 
   close() {
-    return this.indexedDBManager?.close();
+    clearTimeout(this.cleanupTimer);
+    this.cleanupTimer = null;
+    this.blobStore.clear();
+    this.blobStorePromises.clear();
+    return this.closeBackend();
   }
 }

--- a/chrome/player/network/DownloadManager.mjs
+++ b/chrome/player/network/DownloadManager.mjs
@@ -23,6 +23,13 @@ export class DownloadManager {
     this.failed = 0;
 
     this.blobStore = new FSBlob();
+    this.storageConfig = {
+      persistBufferedVideos: false,
+      persistBufferRetentionDays: 7,
+      persistBufferMaxSizeMB: 0,
+    };
+    this.storageConfigPromise = Promise.resolve();
+    this.setOptions(this.client?.options || {});
   }
 
   getCompletedEntries() {
@@ -49,9 +56,37 @@ export class DownloadManager {
     const identifier = this.getIdentifier(entry);
     await this.blobStore.saveBlobAsync(entry.data, identifier);
 
-    entry.data = () => {
-      return this.blobStore.getBlob(identifier);
+    entry.data = async () => {
+      const blobEntry = await this.blobStore.getStoredBlobEntry(identifier);
+      return blobEntry?.data || null;
     };
+  }
+
+  setOptions(options = {}) {
+    const persistBufferedVideos = !!options.persistBufferedVideos;
+    const persistBufferRetentionDays = Math.min(Math.max(parseInt(options.persistBufferRetentionDays ?? 7, 10), 1), 30);
+    const persistBufferMaxSizeMB = Math.max(parseInt(options.persistBufferMaxSizeMB ?? 0, 10), 0);
+
+    const changed =
+      this.storageConfig.persistBufferedVideos !== persistBufferedVideos ||
+      this.storageConfig.persistBufferRetentionDays !== persistBufferRetentionDays ||
+      this.storageConfig.persistBufferMaxSizeMB !== persistBufferMaxSizeMB;
+
+    if (!changed) return;
+
+    this.storageConfig = {
+      persistBufferedVideos,
+      persistBufferRetentionDays,
+      persistBufferMaxSizeMB,
+    };
+
+    this.storageConfigPromise = this.blobStore.configure({
+      enabled: this.storageConfig.persistBufferedVideos,
+      retentionDays: this.storageConfig.persistBufferRetentionDays,
+      maxBytes: this.storageConfig.persistBufferMaxSizeMB * 1024 * 1024,
+    }).catch((e) => {
+      console.warn('Failed to configure blob storage backend', e);
+    });
   }
 
   setEntry(entry) {
@@ -156,20 +191,101 @@ export class DownloadManager {
     }
 
     if (storedEntry.status === DownloadStatus.WAITING) {
-      storedEntry.priority = priority;
-
-      // append to end of priority queue
-      let ind = this.queue.length;
-      while (ind > 0 && this.queue[ind - 1].priority < priority) {
-        ind--;
-      }
-      this.queue.splice(ind, 0, storedEntry);
-
-      storedEntry.status = DownloadStatus.ENQUEUED;
-      this.queueNext();
+      this.resolveEntryFromStorageOrQueue(storedEntry, priority).catch((e) => {
+        console.warn('Failed to resolve storage entry', e);
+        if (storedEntry.status === DownloadStatus.WAITING) {
+          this.enqueueEntry(storedEntry, storedEntry.pendingPriority || priority);
+        }
+      });
     }
 
     return watcher;
+  }
+
+  enqueueEntry(entry, priority) {
+    if (entry.status !== DownloadStatus.WAITING) return;
+
+    entry.priority = priority;
+
+    // append to end of priority queue
+    let ind = this.queue.length;
+    while (ind > 0 && this.queue[ind - 1].priority < priority) {
+      ind--;
+    }
+    this.queue.splice(ind, 0, entry);
+
+    entry.status = DownloadStatus.ENQUEUED;
+    this.queueNext();
+  }
+
+  async resolveEntryFromStorageOrQueue(entry, priority) {
+    if (entry.status !== DownloadStatus.WAITING) return;
+
+    if (!entry.pendingPriority || entry.pendingPriority < priority) {
+      entry.pendingPriority = priority;
+    }
+
+    if (entry.cacheLookupPromise) return;
+
+    entry.cacheLookupPromise = (async () => {
+      await this.storageConfigPromise;
+      const identifier = this.getIdentifier(entry);
+      const record = await this.blobStore.getStoredBlobEntry(identifier);
+      if (!record) return false;
+      if (entry.status !== DownloadStatus.WAITING) return true;
+
+      const now = self.performance?.now ? self.performance.now() : Date.now();
+      entry.status = DownloadStatus.DOWNLOAD_COMPLETE;
+      entry.dataSize = record.size || 0;
+      entry.data = async () => {
+        const blobEntry = await this.blobStore.getStoredBlobEntry(identifier);
+        return blobEntry?.data || null;
+      };
+      entry.responseHeaders = {};
+      entry.responseURL = entry.url;
+      entry.stats = {
+        aborted: false,
+        timedout: false,
+        loaded: entry.dataSize,
+        total: entry.dataSize,
+        retry: 0,
+        chunkCount: 0,
+        bwEstimate: 0,
+        loading: {
+          start: now,
+          first: now,
+          end: now,
+        },
+        parsing: {
+          start: now,
+          end: now,
+        },
+        buffering: {
+          start: now,
+          first: now,
+          end: now,
+        },
+      };
+
+      entry.watchers.forEach((watcher) => {
+        watcher.callbacks.onSuccess(entry);
+      });
+      entry.cleanup();
+      return true;
+    })();
+
+    let restored = false;
+    try {
+      restored = await entry.cacheLookupPromise;
+    } catch (e) {
+      console.warn('Persistent storage lookup failed', e);
+    } finally {
+      entry.cacheLookupPromise = null;
+    }
+
+    if (!restored && entry.status === DownloadStatus.WAITING) {
+      this.enqueueEntry(entry, entry.pendingPriority || priority);
+    }
   }
 
   getSpeed() {
@@ -339,23 +455,26 @@ export class DownloadManager {
     this.failed = 0;
 
     if (!this.dontClearStorage) {
-      await this.clearStorage();
+      await this.clearStorage(this.storageConfig.persistBufferedVideos);
     }
 
     this.downloaders?.push(new StandardDownloader(this));
   }
 
   async setup() {
-
+    this.setOptions(this.client?.options || {});
+    await this.storageConfigPromise;
   }
 
   resetOverride(value) {
     this.dontClearStorage = value;
   }
 
-  async clearStorage() {
+  async clearStorage(preservePersistent = false) {
     this.storage.clear();
-    await this.blobStore.clear();
+    await this.blobStore.clear({
+      clearPersistent: !preservePersistent,
+    });
   }
 
   abortAll() {

--- a/chrome/player/network/IndexedDBManager.mjs
+++ b/chrome/player/network/IndexedDBManager.mjs
@@ -1,4 +1,5 @@
 const closeQueue = [];
+const DB_VERSION = 4;
 
 export class IndexedDBManager {
   constructor(persistentName) {
@@ -120,19 +121,24 @@ export class IndexedDBManager {
   }
 
   static async requestDB(dbName, open = false) {
-    const request = window.indexedDB.open(dbName, 3);
-    if (open) {
-      request.onupgradeneeded = async (event) => {
-        const db = event.target.result;
+    const request = window.indexedDB.open(dbName, DB_VERSION);
+    request.onupgradeneeded = async (event) => {
+      const db = event.target.result;
+      if (!db.objectStoreNames.contains('metadata')) {
         db.createObjectStore('metadata');
+      }
+      if (!db.objectStoreNames.contains('files')) {
         db.createObjectStore('files');
-        if (!window.indexedDB.databases) {
-          const databases = JSON.parse(localStorage.getItem('fs_temp_databases') || '[]');
-          if (!databases.includes(dbName)) databases.push(dbName);
-          localStorage.setItem('fs_temp_databases', JSON.stringify(databases));
-        }
-      };
-    }
+      }
+      if (!db.objectStoreNames.contains('file_meta')) {
+        db.createObjectStore('file_meta');
+      }
+      if (open && !window.indexedDB.databases) {
+        const databases = JSON.parse(localStorage.getItem('fs_temp_databases') || '[]');
+        if (!databases.includes(dbName)) databases.push(dbName);
+        localStorage.setItem('fs_temp_databases', JSON.stringify(databases));
+      }
+    };
     return IndexedDBManager.wrapRequest(request, 5000);
   }
 
@@ -175,6 +181,14 @@ export class IndexedDBManager {
     });
   }
 
+  async clearFileMetadataStorage() {
+    if (!this.db) return;
+    return IndexedDBManager.transact(this.db, 'file_meta', 'readwrite', (transaction)=>{
+      const metaDataStore = transaction.objectStore('file_meta');
+      return IndexedDBManager.wrapRequest(metaDataStore.clear());
+    });
+  }
+
   async getFile(identifier) {
     return IndexedDBManager.getValue(this.db, 'files', identifier);
   }
@@ -191,6 +205,25 @@ export class IndexedDBManager {
       const fileStore = transaction.objectStore('files');
       return IndexedDBManager.wrapRequest(fileStore.delete(identifier));
     });
+  }
+
+  async getFileMetadata(identifier) {
+    return IndexedDBManager.getValue(this.db, 'file_meta', identifier);
+  }
+
+  async setFileMetadata(identifier, metadata) {
+    return IndexedDBManager.setValue(this.db, 'file_meta', identifier, metadata);
+  }
+
+  async deleteFileMetadata(identifier) {
+    return IndexedDBManager.transact(this.db, 'file_meta', 'readwrite', (transaction)=>{
+      const metaStore = transaction.objectStore('file_meta');
+      return IndexedDBManager.wrapRequest(metaStore.delete(identifier));
+    });
+  }
+
+  async getAllFileMetadata() {
+    return IndexedDBManager.getAllValues(this.db, 'file_meta');
   }
 
   getDatabase() {
@@ -225,6 +258,13 @@ export class IndexedDBManager {
 
       result = callback(transaction);
       transaction.commit();
+    });
+  }
+
+  static getAllValues(db, storeName) {
+    return IndexedDBManager.transact(db, storeName, 'readonly', (transaction)=>{
+      const store = transaction.objectStore(storeName);
+      return IndexedDBManager.wrapRequest(store.getAll());
     });
   }
 

--- a/chrome/player/options/defaults/DefaultOptions.mjs
+++ b/chrome/player/options/defaults/DefaultOptions.mjs
@@ -46,5 +46,8 @@ export const DefaultOptions = {
   miniPos: MiniplayerPositions.BOTTOM_RIGHT,
   videoDelay: 0,
   maximumDownloaders: 6,
+  persistBufferedVideos: true,
+  persistBufferRetentionDays: 7,
+  persistBufferMaxSizeMB: 1024,
   youtubePlayerID: '',
 };

--- a/chrome/player/options/index.html
+++ b/chrome/player/options/index.html
@@ -190,6 +190,32 @@
                 <div class="search-target-remove">
                     <br>
                     <div class="option grid1">
+                        <input type="checkbox" id="persistbufferedvideos" data-i18n-label="options_general_persistbuffer">
+                        <div class="label search-target-text" data-i18n="options_general_persistbuffer"></div>
+                    </div>
+                </div>
+
+                <div class="search-target-remove">
+                    <br>
+                    <div class="option grid2">
+                        <div class="label search-target-text" data-i18n="options_general_persistbuffer_retention"></div>
+                        <input class="number" type="number" id="persistbufferretentiondays" min="1" max="30" step="1"
+                            data-i18n-label="options_general_persistbuffer_retention"></input>
+                    </div>
+                </div>
+
+                <div class="search-target-remove">
+                    <br>
+                    <div class="option grid2">
+                        <div class="label search-target-text" data-i18n="options_general_persistbuffer_maxsize"></div>
+                        <input class="number" type="number" id="persistbuffermaxsizemb" min="0" step="128"
+                            data-i18n-label="options_general_persistbuffer_maxsize"></input>
+                    </div>
+                </div>
+
+                <div class="search-target-remove">
+                    <br>
+                    <div class="option grid1">
                         <input type="checkbox" id="previewenabled" data-i18n-label="options_general_previewenabled">
                         <div class="label search-target-text" data-i18n="options_general_previewenabled"></div>
                     </div>

--- a/chrome/player/options/options.mjs
+++ b/chrome/player/options/options.mjs
@@ -41,6 +41,9 @@ const visChangeAction = document.getElementById('vischangeaction');
 const customSourcePatterns = document.getElementById('customSourcePatterns');
 const showWhenMiniSelected = document.getElementById('showWhenMiniSelected');
 const storeProgress = document.getElementById('storeprogress');
+const persistBufferedVideos = document.getElementById('persistbufferedvideos');
+const persistBufferRetentionDays = document.getElementById('persistbufferretentiondays');
+const persistBufferMaxSizeMB = document.getElementById('persistbuffermaxsizemb');
 const miniSize = document.getElementById('minisize');
 const miniPos = document.getElementById('minipos');
 const daltonizerType = document.getElementById('daltonizerType');
@@ -108,6 +111,10 @@ async function loadOptions(newOptions) {
   replaceDelay.value = Options.replaceDelay;
   maxdownloaders.value = Options.maximumDownloaders;
   ytPlayerID.value = Options.youtubePlayerID;
+  persistBufferedVideos.checked = !!Options.persistBufferedVideos;
+  persistBufferRetentionDays.value = Math.min(Math.max(parseInt(Options.persistBufferRetentionDays ?? 7, 10), 1), 30);
+  persistBufferMaxSizeMB.value = Math.max(parseInt(Options.persistBufferMaxSizeMB ?? 0, 10), 0);
+  updatePersistentBufferOptionsState();
 
   setSelectMenuValue(daltonizerType, Options.videoDaltonizerType);
   setSelectMenuValue(clickAction, Options.singleClickAction);
@@ -159,6 +166,12 @@ async function loadOptions(newOptions) {
     document.getElementById('dev').style.display = '';
   }
   initsearch();
+}
+
+function updatePersistentBufferOptionsState() {
+  const enabled = persistBufferedVideos.checked;
+  persistBufferRetentionDays.disabled = !enabled;
+  persistBufferMaxSizeMB.disabled = !enabled;
 }
 
 function createSelectMenu(container, options, selected, localPrefix, callback) {
@@ -386,6 +399,26 @@ previewEnabled.addEventListener('change', () => {
 
 storeProgress.addEventListener('change', () => {
   Options.storeProgress = storeProgress.checked;
+  optionChanged();
+});
+
+persistBufferedVideos.addEventListener('change', () => {
+  Options.persistBufferedVideos = persistBufferedVideos.checked;
+  updatePersistentBufferOptionsState();
+  optionChanged();
+});
+
+persistBufferRetentionDays.addEventListener('change', () => {
+  const value = Math.min(Math.max(parseInt(persistBufferRetentionDays.value, 10) || 7, 1), 30);
+  persistBufferRetentionDays.value = value;
+  Options.persistBufferRetentionDays = value;
+  optionChanged();
+});
+
+persistBufferMaxSizeMB.addEventListener('change', () => {
+  const value = Math.max(parseInt(persistBufferMaxSizeMB.value, 10) || 0, 0);
+  persistBufferMaxSizeMB.value = value;
+  Options.persistBufferMaxSizeMB = value;
   optionChanged();
 });
 


### PR DESCRIPTION
## Summary
Adds persistent buffered video chunk caching so already-downloaded segments are reused after page refresh/reopen.

## Problem
Buffered data is currently session/memory-bound. After refresh, users re-download the same chunks, which hurts resume time and bandwidth usage.

Related issue: #487

## Approach
- Added persistent chunk storage in IndexedDB with metadata (`createdAt`, `lastAccessed`, `size`, `cacheVersion`).
- Added cleanup/retention controls:
  - TTL-based expiration (`retentionDays`, configurable)
  - Size cap with eviction (`maxBytes`, expired-first then LRU)
- Updated download flow to check persistent cache before network fetch and serve cache hits as completed entries.
- Added runtime options and wiring:
  - `persistBufferedVideos` (enable/disable)
  - `persistBufferRetentionDays` (`1-30`)
  - `persistBufferMaxSizeMB` (`0 = unlimited`)
- Added options UI controls and English locale labels.

## Defaults
- Persistence: enabled
- Retention: 7 days
- Max cache size: 1024 MB
- Incognito: non-persistent

## Testing
- Manual test in Chrome unpacked extension:
  - Play video once and allow buffering
  - Refresh/reopen tab
  - Replay resumes with cached chunks and avoids full re-download
- Regression check for cached-hit playback path after reload (fixed loader-stats shape issue).
- Lint run on touched modules:
  - `npx eslint --rule "linebreak-style: off" ...`

## Screenshots / Video
- Not included (non-visual behavior change in buffering/storage pipeline).

## Trade-offs / Concerns
- Browser quota behavior varies; eviction is best-effort and browser may still evict data.
- Large persistent caches can consume disk space; user controls are provided.
- This PR currently includes English strings only; other locales can be added in follow-up.

## Changed Areas
- Storage backend:
  - `chrome/player/network/IndexedDBManager.mjs`
  - `chrome/player/modules/FSBlob.mjs`
- Download/cache integration:
  - `chrome/player/network/DownloadManager.mjs`
- Runtime option model:
  - `chrome/player/FastStreamClient.mjs`
  - `chrome/player/options/defaults/DefaultOptions.mjs`
- Settings UI + i18n:
  - `chrome/player/options/index.html`
  - `chrome/player/options/options.mjs`
  - `chrome/_locales/en/messages.json`

## Reviewer Notes
- Single concern PR: persistent buffered chunk reuse across reload with retention and eviction controls.
- Main review focus:
  - cache hit correctness
  - cleanup/eviction behavior
  - option wiring consistency

## Screenshot
<img width="611" height="638" alt="image" src="https://github.com/user-attachments/assets/33aed3f0-6a14-4835-b3e5-5a6f0c2498b8" />
