### PR TITLE
Fix: Silence skipper initializing videos at 2x speed

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -3,7 +3,7 @@
   "default_locale": "en",
   "name": "__MSG_extension_name__",
   "description": "__MSG_extension_description__",
-  "version": "1.3.74",
+  "version": "1.3.73",
   "author": "Andrew S",
   "options_ui": {
     "page": "player/options/index.html",

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -3,7 +3,7 @@
   "default_locale": "en",
   "name": "__MSG_extension_name__",
   "description": "__MSG_extension_description__",
-  "version": "1.3.73",
+  "version": "1.3.74",
   "author": "Andrew S",
   "options_ui": {
     "page": "player/options/index.html",

--- a/chrome/player/ui/InterfaceController.mjs
+++ b/chrome/player/ui/InterfaceController.mjs
@@ -213,6 +213,7 @@ export class InterfaceController {
     DOMElements.playerContainer.classList.add('controls_visible');
     this.updateToolVisibility();
     this.fineTimeControls.reset();
+    this.playbackRateChanger.reset();
   }
 
   failedToLoad(reason) {

--- a/chrome/player/ui/menus/PlaybackRateChanger.mjs
+++ b/chrome/player/ui/menus/PlaybackRateChanger.mjs
@@ -174,14 +174,17 @@ export class PlaybackRateChanger extends EventEmitter {
     const outputRate = this.client.audioAnalyzer.getOutputRate();
     const minIndex = Math.floor((time - this.audioPaddingEnd) * outputRate);
     const maxIndex = Math.floor((time + this.audioPaddingStart) * outputRate);
+
+    let hasData = false;
     for (let i = minIndex; i < maxIndex; i++) {
       if (volumeBuffer[i] === undefined) continue;
+      hasData = true;
       const volume = Utils.clamp((volumeBuffer[i] - minDB) / dbRange, 0, 1);
       if (volume >= this.silenceThreshold) {
         return false;
       }
     }
-    return true;
+    return hasData; // Don't skip silence if we have no audio data yet
   }
 
   enableSilenceSkipper() {
@@ -262,7 +265,17 @@ export class PlaybackRateChanger extends EventEmitter {
     this.stayOpen = false;
     return true;
   }
-
+  
+  reset() {
+    // Reset silence skipper state when a new video loads
+    if (this.silenceSkipperActive) {
+      this.disableSilenceSkipper();
+    }
+    this.silenceSkipperLoopRunning = false;
+    this.regularSpeed = 1;
+    this.silenceSkipSpeed = this.maxPlaybackRate;
+  }
+  
   isOpen() {
     return DOMElements.playbackRateMenuContainer.style.display !== 'none';
   }


### PR DESCRIPTION
I kept this PR as minimal as possible since I had my friend Claude helping me. I've had it running for a week or two now and haven't noticed videos playing briefly at 2x speed any more. A little issue that's bugged me far too long.

----

This introduces improvements to the playback rate and silence skipping functionality in the player UI, ensuring that silence skipping is properly reset when a new video loads and that silence is not skipped if there is no audio data available. Additionally, the extension version has been incremented.

Enhancements to playback rate and silence skipping:

* Added a `reset` method to the `PlaybackRateChanger` class, which disables silence skipping and resets relevant state variables when a new video loads.
* Integrated the `reset` method into the `InterfaceController` so it is called during player resets, ensuring consistent state across video loads.
* Improved the silence detection logic in `PlaybackRateChanger` by returning `false` if no audio data is available, preventing premature silence skipping.

Version update:

* Incremented the extension version in `manifest.json` from `1.3.73` to `1.3.74`.

Hope this is okay, cheers!