### PR TITLE
Fix loop to default to full video when start/end are unset

### DIFF
--- a/chrome/player/ui/menus/LoopMenu.mjs
+++ b/chrome/player/ui/menus/LoopMenu.mjs
@@ -165,19 +165,29 @@ export class LoopMenu extends EventEmitter {
       this.loopStart = this.timecodeToSeconds(this.loopTimeSettings.start);
       this.loopEnd = this.timecodeToSeconds(this.loopTimeSettings.end);
 
-      if (this.loopEnd <= 0) {
-        this.loopEnd = this.client.duration;
-      }
+      // When both start and end are 0 (defaults), loop the full video
+      // using native video.loop without custom seeking
+      this.isFullVideoLoop = (this.loopStart <= 0 && this.loopEnd <= 0);
 
-      if (this.loopStart >= this.loopEnd || this.loopStart >= this.client.duration) {
-        this.loopEnabled = false;
+      if (this.isFullVideoLoop) {
+        this.loopStart = 0;
+        this.loopEnd = this.client.duration || Infinity;
       } else {
-        this.loopStart = Utils.clamp(this.loopStart, 0, this.client.duration);
-        this.loopEnd = Utils.clamp(this.loopEnd, 0, this.client.duration);
+        if (this.loopEnd <= 0) {
+          this.loopEnd = this.client.duration;
+        }
+
+        if (this.loopStart >= this.loopEnd || this.loopStart >= this.client.duration) {
+          this.loopEnabled = false;
+        } else {
+          this.loopStart = Utils.clamp(this.loopStart, 0, this.client.duration);
+          this.loopEnd = Utils.clamp(this.loopEnd, 0, this.client.duration);
+        }
       }
     } else {
       this.loopStart = null;
       this.loopEnd = null;
+      this.isFullVideoLoop = false;
     }
 
     this.toggleLoopButton.textContent = Localize.getMessage('loop_menu_toggle_' + (this.loopEnabled ? 'enabled' : 'disabled'));
@@ -189,7 +199,9 @@ export class LoopMenu extends EventEmitter {
 
     if (this.loopEnabled) {
       player.getVideo().loop = true;
-      this.startLoopLoop();
+      if (!this.isFullVideoLoop) {
+        this.startLoopLoop();
+      }
     } else {
       player.getVideo().loop = false;
     }
@@ -349,6 +361,12 @@ export class LoopMenu extends EventEmitter {
   checkLoopLoop() {
     const player = this.client.player;
     if (!player || !this.loopEnabled) {
+      this.loopLoopRunning = false;
+      return;
+    }
+
+    // Full video loop is handled by native video.loop, no custom seeking needed
+    if (this.isFullVideoLoop) {
       this.loopLoopRunning = false;
       return;
     }


### PR DESCRIPTION
## Summary

- When both start and end times are at their defaults (`00:00:00.000`), toggling loop now correctly loops the full video using native `video.loop`
- Previously, enabling loop without setting explicit times could fail because `client.duration` may be 0 or unavailable at toggle time, causing `loopStart >= loopEnd` (0 >= 0) to immediately disable the loop
- Custom section looping (with user-set start/end times) is completely unchanged

## Problem

The loop feature requires manually setting start and end times to work. If a user just wants to loop the entire video (the most common use case), they have to explicitly set the end time — simply toggling the loop button with default values does nothing because:

1. `loopEnd` is parsed as 0 from `00:00:00.000`
2. The fallback `this.loopEnd = this.client.duration` can resolve to 0 or NaN if duration isn't available yet
3. The check `this.loopStart >= this.loopEnd` (0 >= 0) evaluates to `true` → loop gets disabled immediately

## Fix

Added an `isFullVideoLoop` flag: when both start=0 and end=0, the code skips the duration-dependent validation entirely and relies on native `video.loop = true` (which always works). The `checkLoopLoop` RAF loop is not started in this case since native looping handles it.

## Test plan

- [ ] Toggle loop with default times (00:00:00.000 / 00:00:00.000) → video should loop the full video
- [ ] Set custom start/end times → section loop should work as before
- [ ] GIF recording with custom loop bounds should work as before


🤖 Generated with [Claude Code](https://claude.com/claude-code)