### PR TITLE
Fix build on Windows: parameter shadowed volumeNameLen in cleanGlobPath

### DIFF
--- a/miniglob.mjs
+++ b/miniglob.mjs
@@ -65,8 +65,7 @@ const volumeNameLen = WIN32 ? (path) => {
 // cleanGlobPath(path :string) : [prefixLen int, cleaned string]
 //
 const cleanGlobPath = (
-  WIN32 ? (path, volumeNameLen) => { // (prefixLen int, cleaned string)
-    let vollen = volumeNameLen(path);
+  WIN32 ? (path, vollen) => { // (prefixLen int, cleaned string)
     if (path == '') {
       return [0, '.'];
     }
@@ -81,15 +80,15 @@ const cleanGlobPath = (
       vollen = path.length - 1;
     }
     return [vollen, path.substr(0, path.length-1)]; // chop off trailing separator
-  } : (path, volumeNameLen) => {
+  } : (path, vollen) => {
     if (path == '') {
-      return [volumeNameLen, '.'];
+      return [vollen, '.'];
     }
     if (path == DIRSEP) {
       // do nothing to the path
-      return [volumeNameLen, path];
+      return [vollen, path];
     }
-    return [volumeNameLen, path.substr(0, path.length-1)]; // chop off trailing separator
+    return [vollen, path.substr(0, path.length-1)]; // chop off trailing separator
   }
 );
 


### PR DESCRIPTION
`node build.mjs` currently fails immediately on Windows:

```
TypeError: volumeNameLen is not a function
    at miniglob.mjs:69:18
    at glob0 (miniglob.mjs:279:23)
    at glob (miniglob.mjs:34:12)
    at build.mjs:19:1
```

## Cause

`cleanGlobPath`'s second parameter is named `volumeNameLen`, which shadows the module-level `volumeNameLen()` function. The Windows branch then tries to call it — but the caller passes a **number**:

```js
let volumeLen = volumeNameLen(pattern);      // number
;[volumeLen, dir] = cleanGlobPath(dir, volumeLen);
```

The POSIX branch treats that same parameter correctly as a number (`return [volumeNameLen, '.']`), which is why this only ever surfaced on Windows.

## Fix

Renamed the parameter to `vollen` in both branches and dropped the redundant `volumeNameLen(path)` call, using the value the caller already computed.

## Test plan

- [x] `npm run build` completes on Windows 11 / Node 26 — previously died before reaching `build.mjs`
- [x] Produces the same three packages as a Linux build (chrome-libre, chrome-dist, firefox-libre)
- [x] No behaviour change on POSIX — that branch only had a parameter rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)