### PR TITLE
Don't request the contextualIdentities permission in Firefox builds

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -314,7 +314,11 @@ async function buildFirefoxLibre() {
   const manifestPath = path.join(firefoxLibreBuildDir, 'manifest.json');
   const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
 
-  manifest.permissions.push('downloads', 'cookies', 'contextualIdentities');
+  // 'contextualIdentities' is not requested: Firefox scopes that permission
+  // to the browser.contextualIdentities namespace, which nothing here calls.
+  // The container support in background.mjs only reads a tab's
+  // cookieStoreId and passes it to tabs.create(), which 'cookies' covers.
+  manifest.permissions.push('downloads', 'cookies');
 
   // remove the userscripts permission
   manifest.permissions = manifest.permissions.filter((permission) => permission !== 'userScripts');
@@ -371,7 +375,8 @@ async function buildFirefoxDist() {
     type: 'module',
   };
 
-  manifest.permissions.push('downloads', 'cookies', 'contextualIdentities');
+  // see the matching comment in buildFirefoxLibre()
+  manifest.permissions.push('downloads', 'cookies');
 
   // remove the userscripts permission
   manifest.permissions = manifest.permissions.filter((permission) => permission !== 'userScripts');


### PR DESCRIPTION
## Summary

`build.mjs` requests `contextualIdentities` in both Firefox targets, but nothing in the project calls `browser.contextualIdentities.*`. Firefox scopes that permission to exactly that namespace — querying and editing container definitions — so it's dead weight.

The container support in `background.mjs`'s `DOWNLOAD` handler only reads `sender.tab.cookieStoreId` and passes it to `tabs.create()`, and `cookieStoreId` is gated on `"cookies"`, which this still requests.

## Why it's worth doing

Fewer permissions means a smaller install prompt and one less thing for a store reviewer to ask about.

## A warning worth recording

**`cookies` must stay.** I very nearly removed it too, on the strength of a grep for `.cookies.` that found nothing — but `cookieStoreId` doesn't match that pattern, and Mozilla's own schema is explicit:

```
"cookieStoreId": {"type":"string","description":"The cookie store ID of the
contextual identity; requires \"cookies\" permission."}
```

Dropping `cookies` silently breaks container downloads while leaving every test green. Flagging it in case anyone else runs the same grep and reaches the same wrong conclusion.

## Test plan

- [x] `node build.mjs` builds successfully
- [x] Built `firefox-libre` manifest still requests `storage, tabs, webRequest, declarativeNetRequest, downloads, cookies` — container downloads unaffected
- [x] No `browser.contextualIdentities` call site anywhere in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)