### PR TITLE
Add .gitattributes so Windows checkouts get LF endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Store and check out all text files with LF endings.
+#
+# Without this, core.autocrlf=true (the Windows default) hands the working
+# tree CRLF, and eslint-config-google's linebreak-style rule then reports an
+# error on every single line - 2352 of them across this repo. The repository
+# content is already LF throughout, so this changes checkout behaviour only
+# and produces no content diff.
+* text=auto eol=lf
+
+# Binary assets: never convert.
+*.png    binary
+*.wasm   binary
+*.ort    binary
+*.zip    binary
+*.xpi    binary


### PR DESCRIPTION
With `core.autocrlf=true` (the Windows default), a fresh clone gets CRLF in the working tree, and `eslint-config-google`'s `linebreak-style` rule then reports an error on essentially every line — 2352 of them on this repo. That makes linting unusable on Windows, and it's invisible on Linux so it never showed up in your CI.

The repository content is already LF throughout, so this file changes checkout behaviour only — it produces no content diff:

* `* text=auto eol=lf` checks out all text files with LF.
* Binary assets are pinned so they are never converted: `png`, `wasm`, `ort`, `zip`, `xpi`.

Verified on Windows 11: a fresh clone with this file lints at 0 errors, where the same clone without it reports 2352 `linebreak-style` errors.

Pairs with #548 — together they make a Windows checkout buildable and lintable.